### PR TITLE
Fix URI.open deprecation

### DIFF
--- a/lib/mkchain.rb
+++ b/lib/mkchain.rb
@@ -12,7 +12,7 @@ class MkChain
       url = cert.extensions.select { |ext| ext.oid == 'authorityInfoAccess' }
         .first.value.match(%r{^CA Issuers - URI:(https?://.+)$})[1] rescue break
 
-      cert = OpenSSL::X509::Certificate.new(open(url).read) rescue break
+      cert = OpenSSL::X509::Certificate.new(URI.open(url).read) rescue break
       chain << cert.to_pem
     end
 

--- a/mkchain.gemspec
+++ b/mkchain.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'mkchain'
-  s.version = '1.0.2'
+  s.version = '1.0.1'
   s.authors = ['David Adams']
   s.email = 'dadams@instructure.com'
   s.date = Time.now.strftime('%Y-%m-%d')

--- a/mkchain.gemspec
+++ b/mkchain.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'mkchain'
-  s.version = '1.0.1'
+  s.version = '1.0.3'
   s.authors = ['David Adams']
   s.email = 'dadams@instructure.com'
   s.date = Time.now.strftime('%Y-%m-%d')


### PR DESCRIPTION
Specifically fixes:
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
