### PR TITLE
Refactor of mkchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-/pkg
+/*.gem
+/pkg/
+
+.DS_Store

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,50 @@
+plugins:
+  - rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 3.0
+  NewCops: enable
+  Exclude:
+    - 'bin/**/*'
+    - 'Gemfile.lock'
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+  Max: 50
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 30
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/PerceivedComplexity:
+  Max: 8
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+RSpec:
+  Enabled: true
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 15
+
+RSpec/MultipleExpectations:
+  Max: 2

--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,22 @@
+---
+include:
+- "**/*.rb"
+exclude:
+- spec/**/*
+- test/**/*
+- vendor/**/*
+- ".bundle/**/*"
+require: []
+domains: []
+reporters:
+- rubocop
+- require_not_found
+formatter:
+  rubocop:
+    cops: safe
+    except: []
+    only: []
+    extra_args: []
+require_paths: []
+plugins: []
+max_files: 5000

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+gemspec
+
+group :development, :test do
+  gem 'rake'
+  gem 'rspec'
+  gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
+  gem 'solargraph', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,133 @@
+PATH
+  remote: .
+  specs:
+    mkchain (2.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    backport (1.2.0)
+    benchmark (0.4.1)
+    diff-lcs (1.6.2)
+    jaro_winkler (1.6.1)
+    json (2.12.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    nokogiri (1.18.8-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.8-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.8-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.8-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-linux-musl)
+      racc (~> 1.4)
+    observer (0.1.2)
+    ostruct (0.6.2)
+    parallel (1.27.0)
+    parser (3.3.8.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.3.0)
+    rbs (3.9.4)
+      logger
+    regexp_parser (2.10.0)
+    reverse_markdown (3.0.0)
+      nokogiri
+    rexml (3.4.1)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
+    rubocop (1.78.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.45.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.45.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-rspec (3.6.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+    ruby-progressbar (1.13.0)
+    solargraph (0.56.0)
+      backport (~> 1.2)
+      benchmark (~> 0.4)
+      bundler (~> 2.0)
+      diff-lcs (~> 1.4)
+      jaro_winkler (~> 1.6, >= 1.6.1)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      logger (~> 1.6)
+      observer (~> 0.1)
+      ostruct (~> 0.6)
+      parser (~> 3.0)
+      prism (~> 1.4)
+      rbs (~> 3.3)
+      reverse_markdown (~> 3.0)
+      rubocop (~> 1.38)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
+      yard-solargraph (~> 0.1)
+    thor (1.3.2)
+    tilt (2.6.1)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+    yard (0.9.37)
+    yard-solargraph (0.1.0)
+      yard (~> 0.9)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  mkchain!
+  rake
+  rspec
+  rubocop
+  rubocop-rspec
+  solargraph
+
+BUNDLED WITH
+   2.6.2

--- a/README.md
+++ b/README.md
@@ -5,23 +5,22 @@ intermediate certificate chain, and print it to stdout. This replaces the
 need to copy/edit cert-vendor provided chain files and deal with certificate
 order.
 
-
 ## Installation
 
     $ rake install
 
-
 ## Command-line Usage
 
     $ mkchain site.example.com.crt > site.example.com.chain
-
+    $ mkchain -c 2025-05-30 site.example.com.crt > site.example.com.chain
+    $ mkchain -lr site.example.com.crt > site.example.com.fullchain
 
 ## Ruby Library
 
 You can also invoke `mkchain` from Ruby code:
 
     require 'mkchain'
-    chain_str = MkChain.chain(File.read(cert_filename))
+    chain_str = MkChain.new(include_root: true).chain(File.read(cert_filename))
 
 This method returns a string containing the contents of the intermediate
 chain in PEM format. If no chain can be built from the certificate, a
@@ -29,13 +28,11 @@ chain in PEM format. If no chain can be built from the certificate, a
 (ie, if the certificate was signed directly by the root CA), then an empty
 string will be returned.
 
-
 ## No guarantee
 
 This method of building an intermediate chain depends on the signing
 certificate being in the `authorityInfoAccess` X.509 extension field under
 `CA Issuers`. That's a common but not universal pattern.
-
 
 ## Similar Tools
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/mkchain
+++ b/bin/mkchain
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'mkchain'
 
-abort 'Usage: mkchain <cert-filename>' unless ARGV.count == 1
-
-filename = ARGV[0]
-abort "No such file '#{filename}'" unless File.exist?(filename)
-abort "Cannot read file '#{filename}'" unless File.readable?(filename)
-
-puts MkChain.chain(File.read(filename))
+MkChain::CLI.start if __FILE__ == $PROGRAM_NAME

--- a/lib/mkchain.rb
+++ b/lib/mkchain.rb
@@ -1,24 +1,5 @@
-require 'openssl'
-require 'open-uri'
+# frozen_string_literal: true
 
-class MkChain
-  class NoChainFoundException < Exception; end
-
-  def self.chain(cert_str)
-    chain = []
-    cert = OpenSSL::X509::Certificate.new(cert_str)
-
-    loop do
-      url = cert.extensions.select { |ext| ext.oid == 'authorityInfoAccess' }
-        .first.value.match(%r{^CA Issuers - URI:(https?://.+)$})[1] rescue break
-
-      cert = OpenSSL::X509::Certificate.new(URI.open(url).read) rescue break
-      chain << cert.to_pem
-    end
-
-    raise NoChainFoundException, 'No intermediate chain found' if chain.empty?
-
-    # the last cert will be the root cert, which doesn't belong in the chain
-    chain[0..-1].join
-  end
-end
+require_relative 'mkchain/cli'
+require_relative 'mkchain/core'
+require_relative 'mkchain/version'

--- a/lib/mkchain/cli.rb
+++ b/lib/mkchain/cli.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+module MkChain
+  class CLI
+    def self.start(argv = ARGV)
+      new.run(argv)
+    end
+
+    def run(argv)
+      options = parse_options(argv)
+
+      filename = argv.shift&.strip
+      abort 'No certificate file specified.' if filename.nil? || filename.empty?
+      abort "No such file '#{filename}'" unless File.exist?(filename)
+      abort "Cannot read file '#{filename}'" unless File.readable?(filename)
+
+      puts MkChain::Core.new(options).chain(File.read(filename))
+    rescue ArgumentError, MkChain::NoChainFoundException, MkChain::UnknownFormat => e
+      puts "Error: #{e.message}"
+      exit 1
+    rescue StandardError => e
+      puts "Unexpected error: #{e.message}"
+      exit 1
+    end
+
+    private
+
+    def parse_options(argv) # rubocop:disable Metrics/MethodLength
+      options = {
+        include_leaf: false,
+        include_root: false,
+        cacert_date: nil
+      }
+      opt_parser = OptionParser.new do |opts|
+        opts.banner = 'Usage: mkchain [options] <cert-filename>'
+        opts.on('-h', '--help', 'Display this help message') do
+          puts opts
+          exit
+        end
+        opts.on('-l', '--include-leaf', 'Include the leaf certificate') do
+          options[:include_leaf] = true
+        end
+        opts.on('-r', '--include-root', 'Include the root certificate') do
+          options[:include_root] = true
+        end
+        opts.on('-c', '--cacert-date DATE',
+                'Build chain against a specific CA bundle revision for better legacy client ' \
+                'compatibility. See https://curl.se/docs/caextract.html') do |date|
+          options[:cacert_date] = Date.parse(date)
+          require 'net/http'
+          require 'uri'
+          uri = URI("https://curl.se/ca/cacert-#{date}.pem")
+          response = Net::HTTP.get_response(uri)
+          if response.code.to_i != 200
+            raise "No CA bundle found for date #{date}. Please check the date format or availability. " \
+                  'For a subset of available revisions, visit https://curl.se/docs/caextract.html'
+          end
+
+          options[:cacert_date] = date
+        rescue Date::Error
+          puts 'Invalid date format. Use YYYY-MM-DD.'
+          exit 1
+        rescue StandardError => e
+          puts "Error fetching CA bundle: #{e.message}"
+          exit 1
+        end
+        opts.on('-v', '--version', 'Display version information') do
+          puts "mkchain #{MkChain::VERSION}"
+          exit
+        end
+      end
+
+      opt_parser.parse!(argv)
+      options
+    end
+  end
+end

--- a/lib/mkchain/core.rb
+++ b/lib/mkchain/core.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'openssl'
+require 'open-uri'
+
+module MkChain
+  class NoChainFoundException < StandardError; end
+  class UnknownFormat < StandardError; end
+
+  class Core
+    def self.parse_pem(data)
+      # First try to parse as PEM-encoded X.509 certificates
+      begin
+        pem_blocks = data.scan(/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/m).flatten
+        certs = pem_blocks.map do |block|
+          OpenSSL::X509::Certificate.new([
+            '-----BEGIN CERTIFICATE-----',
+            block.strip,
+            '-----END CERTIFICATE-----'
+          ].join("\n"))
+        end
+
+        return certs unless certs.empty?
+      rescue OpenSSL::X509::CertificateError
+        # fall through to try PKCS#7
+      end
+
+      # Otherwise attempt PEM-encoded PKCS#7
+      begin
+        pkcs7 = OpenSSL::PKCS7.new(data)
+        return pkcs7.certificates if pkcs7.certificates.any?
+      rescue OpenSSL::PKCS7::PKCS7Error, ArgumentError
+        # fall through
+      end
+
+      raise UnknownFormat, 'Invalid PEM/PKCS#7 format'
+    end
+
+    def self.parse_der(data)
+      # Try to parse as PKCS#7 format first since it can wrap X.509 certs
+      begin
+        pkcs7 = OpenSSL::PKCS7.new(data)
+        return pkcs7.certificates if pkcs7.certificates.any?
+      rescue OpenSSL::PKCS7::PKCS7Error, ArgumentError
+        # fall through to try X.509 parsing
+      end
+
+      # If it fails, try to parse as a single X.509 certificate
+      begin
+        cert = OpenSSL::X509::Certificate.new(data)
+        return [cert]
+      rescue OpenSSL::X509::CertificateError
+        # fall through
+      end
+
+      raise UnknownFormat, 'Invalid DER format - could not parse as PKCS#7 or X.509'
+    end
+
+    def initialize(options = {})
+      @options = { include_leaf: false, include_root: false, cacert_date: nil }.merge(options)
+    end
+
+    def fetch_certificates(url)
+      @certificate_cache ||= {}
+      return @certificate_cache[url] if @certificate_cache.key?(url)
+
+      result = begin
+        data = URI.parse(url).read
+        if data.start_with?('-----BEGIN ')
+          self.class.parse_pem(data)
+        elsif data.getbyte(0) == 0x30
+          self.class.parse_der(data)
+        else
+          raise UnknownFormat, "Unknown certificate format - found leading bytes: #{data.byteslice(0, 4).unpack('H*')}"
+        end
+      rescue OpenURI::HTTPError => e
+        raise "Failed to fetch certificates from #{url}: #{e.message}"
+      end
+
+      @certificate_cache[url] = result
+      result
+    end
+
+    def chain(cert_str) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
+      # Ensure we have a valid certificate string
+      raise ArgumentError, 'Certificate string cannot be nil or empty' if cert_str.nil? || cert_str.strip.empty?
+
+      # If cacert_date is provided, attempt to load a CA bundle at the specified revision
+      cacert_date = @options.fetch(:cacert_date, nil)
+      cacert_url = "https://curl.se/ca/cacert#{"-#{cacert_date}" if cacert_date}.pem"
+      begin
+        # Download the CA bundle from the specified date to a temporary file
+        require 'tempfile'
+        tempfile = Tempfile.new("cacert-#{cacert_date || 'latest'}.pem")
+        tempfile.binmode
+        tempfile.write(URI.parse(cacert_url).read)
+        tempfile.rewind
+
+        # Load the CA bundle into an OpenSSL::X509::Store
+        ca_store = OpenSSL::X509::Store.new
+        ca_store.add_file(tempfile.path)
+        tempfile.close
+        tempfile.unlink
+      rescue OpenSSL::X509::StoreError => e
+        raise "Failed to load CA bundle (#{cacert_date || 'latest'}): #{e.message}"
+      end
+
+      # Parse the certificate and initialize the chain
+      leaf = OpenSSL::X509::Certificate.new(cert_str)
+      untrusted = []
+
+      # Walk through the certificate chain to find intermediates based on AIA extensions
+      queue = [leaf]
+      while (current = queue.shift)
+        # rubocop:disable Style/SafeNavigationChainLength
+        uri = current.extensions.find { |ext| ext.oid == 'authorityInfoAccess' }
+                     &.value
+                     &.scan(%r{CA Issuers - URI:(https?://\S+)})
+                     &.flatten&.first
+        # rubocop:enable Style/SafeNavigationChainLength
+        next unless uri
+
+        fetch_certificates(uri).each do |c|
+          next if c.subject == c.issuer # Skip self-signed/root certs
+
+          key = [c.subject.to_s, c.issuer.to_s, c.serial]
+          unless untrusted.any? { |u| key == [u.subject.to_s, u.issuer.to_s, u.serial] }
+            untrusted << c
+            queue << c
+          end
+        end
+      end
+      raise NoChainFoundException, 'No intermediate certificates found' if untrusted.empty?
+
+      # Attempt to build the chain from the untrusted certificates using the CA store
+      ctx = OpenSSL::X509::StoreContext.new(ca_store, leaf, untrusted)
+      raise "Failed to verify and build chain: #{ctx.error_string}" unless ctx.verify
+
+      # Collect the chain from the context
+      chain = ctx.chain
+      raise NoChainFoundException, 'No valid certificate chain found' if chain.empty?
+
+      # Remove the root and/or leaf if not requested
+      chain = chain[..-2] if @options[:include_root] == false
+      chain = chain[1..] if @options[:include_leaf] == false
+
+      # Return the chain as an array of PEM-encoded strings
+      chain.join
+    end
+  end
+end

--- a/lib/mkchain/version.rb
+++ b/lib/mkchain/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module MkChain
+  VERSION = '2.0.0'
+end

--- a/mkchain.gemspec
+++ b/mkchain.gemspec
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
+require_relative 'lib/mkchain'
+
 Gem::Specification.new do |s|
   s.name = 'mkchain'
-  s.version = '1.1.0'
-  s.authors = ['David Adams']
-  s.email = 'dadams@instructure.com'
-  s.date = Time.now.strftime('%Y-%m-%d')
+  s.version = MkChain::VERSION
+  s.authors = ['David Adams', 'David Warkentin']
+  s.email = ['dadams@instructure.com', 'dwarkentin@instructure.com']
   s.license = 'MIT'
   s.homepage = 'https://github.com/instructure/mkchain'
   s.required_ruby_version = '>=3.0.0'
@@ -12,12 +15,17 @@ Gem::Specification.new do |s|
   s.description =
     'Creates an intermediate chain file from the given SSL certificate'
 
+  s.metadata = {
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => s.homepage,
+  }
+
   s.require_paths = ['lib']
-  s.files = [
-    'lib/mkchain.rb',
-    'README.md',
-    'mkchain.gemspec'
-  ]
+  s.files = Dir.chdir(File.expand_path(__dir__)) do
+    Dir.glob('lib/**/*.rb') +
+      Dir.glob('bin/*') +
+      %w[README.md LICENSE mkchain.gemspec]
+  end
   s.bindir = 'bin'
   s.executables = ['mkchain']
 end

--- a/spec/lib/mkchain/core_chain_spec.rb
+++ b/spec/lib/mkchain/core_chain_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MkChain::Core do
+  let(:root_key)         { OpenSSL::PKey::RSA.new(2048) }
+  let(:intermediate_key) { OpenSSL::PKey::RSA.new(2048) }
+  let(:leaf_key)         { OpenSSL::PKey::RSA.new(2048) }
+
+  let(:root_name)         { OpenSSL::X509::Name.parse('CN=Test Root CA') }
+  let(:intermediate_name) { OpenSSL::X509::Name.parse('CN=Test Intermediate CA') }
+  let(:leaf_name)         { OpenSSL::X509::Name.parse('CN=example.com') }
+
+  let(:root_cert) do
+    cert = OpenSSL::X509::Certificate.new
+    cert.version    = 2
+    cert.serial     = 1
+    cert.subject    = root_name
+    cert.issuer     = root_name
+    cert.public_key = root_key.public_key
+    cert.not_before = Time.now
+    cert.not_after  = cert.not_before + 3600
+    cert.add_extension \
+      OpenSSL::X509::Extension.new('basicConstraints', 'CA:TRUE', true)
+    cert.add_extension \
+      OpenSSL::X509::Extension.new('keyUsage', 'keyCertSign, cRLSign', true)
+
+    cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
+    cert
+  end
+
+  let(:intermediate_cert) do
+    cert = OpenSSL::X509::Certificate.new
+    cert.version    = 2
+    cert.serial     = 2
+    cert.subject    = intermediate_name
+    cert.issuer     = root_cert.subject
+    cert.public_key = intermediate_key.public_key
+    cert.not_before = Time.now
+    cert.not_after  = cert.not_before + 3600
+    cert.add_extension \
+      OpenSSL::X509::Extension.new('basicConstraints', 'CA:TRUE, pathlen:0', true)
+    cert.add_extension \
+      OpenSSL::X509::Extension.new('keyUsage',
+                                   'digitalSignature, keyCertSign, cRLSign', true)
+
+    cert.sign(root_key, OpenSSL::Digest.new('SHA256'))
+    cert
+  end
+
+  let(:leaf_cert) do
+    cert = OpenSSL::X509::Certificate.new
+    cert.version    = 2
+    cert.serial     = 3
+    cert.subject    = leaf_name
+    cert.issuer     = intermediate_cert.subject
+    cert.public_key = leaf_key.public_key
+    cert.not_before = Time.now
+    cert.not_after  = cert.not_before + 3600
+    cert.add_extension \
+      OpenSSL::X509::Extension.new('authorityInfoAccess',
+                                   'CA Issuers - URI:http://example.com/intermediate.der')
+
+    cert.sign intermediate_key, OpenSSL::Digest.new('SHA256')
+    cert
+  end
+
+  let(:self_cert) do
+    key = OpenSSL::PKey::RSA.new(512)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version    = 2
+    cert.serial     = 4
+    cert.subject    = leaf_name
+    cert.issuer     = leaf_name
+    cert.public_key = leaf_key.public_key
+    cert.not_before = Time.now
+    cert.not_after  = cert.not_before + 3600
+    cert.sign(key, OpenSSL::Digest.new('SHA256'))
+    cert
+  end
+
+  let(:fake_ctx) do
+    instance_double(
+      OpenSSL::X509::StoreContext,
+      verify: true,
+      error_string: nil,
+      chain: [leaf_cert, intermediate_cert, root_cert]
+    )
+  end
+
+  let(:mkchain_default) { described_class.new }
+  let(:mkchain_fullchain) do
+    described_class.new(
+      include_leaf: true,
+      include_root: true,
+      cacert_date: nil
+    )
+  end
+
+  before do
+    # stub the network fetch for our mkchain instances so .chain will enqueue our intermediate
+    [mkchain_default, mkchain_fullchain].each do |mkchain|
+      allow(mkchain).to receive(:fetch_certificates)
+        .with('http://example.com/intermediate.der')
+        .and_return([intermediate_cert])
+    end
+
+    # intercept the CA-bundle download to avoid network calls
+    allow(URI).to receive(:parse).and_wrap_original do |orig, url|
+      if url =~ %r{^https://curl\.se/ca/cacert(-\d{4}-\d{2}-\d{2})?\.pem$}
+        instance_double(OpenURI::OpenRead, read: root_cert.to_pem)
+      else
+        orig.call(url)
+      end
+    end
+
+    # stub StoreContext to always verify and yield our fake chain
+    allow(OpenSSL::X509::StoreContext).to receive(:new)
+      .and_return(fake_ctx)
+  end
+
+  describe '.chain input' do
+    it 'errors when input is nil' do
+      expect { mkchain_default.chain(nil) }
+        .to raise_error(ArgumentError, /cannot be nil or empty/)
+    end
+
+    it 'errors when input is empty' do
+      expect { mkchain_default.chain('   ') }
+        .to raise_error(ArgumentError, /cannot be nil or empty/)
+    end
+
+    it 'errors when no intermediates found' do
+      expect { mkchain_default.chain(self_cert.to_pem) }
+        .to raise_error(MkChain::NoChainFoundException, /No intermediate/)
+    end
+  end
+
+  describe '.chain output' do
+    context 'with default flags' do
+      subject(:pem) { mkchain_default.chain(leaf_cert.to_pem) }
+
+      it 'includes only the intermediate certificate' do
+        expect(pem).to include intermediate_cert.to_pem
+      end
+
+      it 'does not include the root certificate' do
+        expect(pem).not_to include root_cert.to_pem
+      end
+    end
+
+    context 'when include_leaf and include_root are true' do
+      subject(:pem) do
+        mkchain_fullchain.chain(leaf_cert.to_pem)
+      end
+
+      it 'starts with the leaf certificate' do
+        expect(pem).to start_with(leaf_cert.to_pem)
+      end
+
+      it 'ends with the root certificate' do
+        expect(pem).to end_with(root_cert.to_pem)
+      end
+    end
+  end
+end

--- a/spec/lib/mkchain/core_parse_spec.rb
+++ b/spec/lib/mkchain/core_parse_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MkChain::Core do
+  # Single valid cert for basic parsing tests
+  let(:valid_pem) do
+    key = OpenSSL::PKey::RSA.new(512)
+    name = OpenSSL::X509::Name.parse('CN=Test')
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = name
+    cert.issuer = name
+    cert.public_key = key.public_key
+    cert.not_before = Time.now
+    cert.not_after = Time.now + 3600
+    cert.sign(key, OpenSSL::Digest.new('SHA256'))
+    cert.to_pem
+  end
+
+  describe '.parse_pem' do
+    it 'returns an array of certificates for valid PEM' do
+      certs = described_class.parse_pem(valid_pem)
+      expect(certs).to all(be_a(OpenSSL::X509::Certificate))
+    end
+
+    it 'raises UnknownFormat for garbage data' do
+      expect { described_class.parse_pem('NOT A CERT') }
+        .to raise_error(MkChain::UnknownFormat)
+    end
+  end
+
+  describe '.parse_der' do
+    let(:der_data) { OpenSSL::X509::Certificate.new(valid_pem).to_der }
+
+    it 'returns array of cert for DER-encoded X.509' do
+      certs = described_class.parse_der(der_data)
+      expect(certs.first.subject.to_s).to include('CN=Test')
+    end
+
+    it 'raises UnknownFormat for invalid DER' do
+      expect { described_class.parse_der('01020304') }
+        .to raise_error(MkChain::UnknownFormat)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'mkchain'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
This is a pretty large update to mkchain to fix a number of issues and make it more resilient. We have encountered many times where it fails to correctly generate a valid chain and may only output a partial or empty chain. After looking at a number of scenarios where this has happened I figured it would be good to just refactor a lot of what it does and see if we could improve the tool as a whole. One of the common scenarios where an incomplete chain could be made is when an AIA URI is encountered that leads to a PKCS#7 bundle rather than a single certificate for an intermediate. This solves the issue by detecting the format and extracting all of the certs if it's a bundle. Additionally the code will have OpenSSL do the work to determine a correct/valid chain instead of trying to build it ourselves... in theory this should be much more robust.

The main reason there are so many changes is because I got carried away with improvements and adding tests. Hopefully that means it will be better and more resilient in the future.

Test plan:
  - Tests using rspec and linting using rubocop are both clean
  - See that generating chains from various leaf certificates works correctly:
    ```sh
    # Intermediate(s) only
    mkchain <certificate.crt>

    # Leaf and root included as well
    mkchain -lr <certificate.crt>

    # Use an older CA bundle to ensure the chain better supports older clients
    mkchain -c 2023-05-30 <certificate.crt>
    ```