### PR TITLE
Fix broken cli call

### DIFF
--- a/bin/mkchain
+++ b/bin/mkchain
@@ -3,4 +3,4 @@
 
 require 'mkchain'
 
-MkChain::CLI.start if __FILE__ == $PROGRAM_NAME
+MkChain::CLI.start


### PR DESCRIPTION
I apparently wasn't thinking clearly about how the script behaves when it's installed on the system. __FILE__ and $PROGRAM_NAME are not equal in that case... oops.

Simple fix but necessary

Refs: CSRE-3278